### PR TITLE
Dependencies updated for NuGet

### DIFF
--- a/Build/combres.log4net/combres.log4net.nuspec
+++ b/Build/combres.log4net/combres.log4net.nuspec
@@ -13,8 +13,8 @@
 		<tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed logging log4net</tags>
 		<language>en-US</language>
 		<dependencies>
-			<dependency id="combres" version="[2.3.0.4]" />
-			<dependency id="log4net" version="[2.0.3]" />
+			<dependency id="combres" version="2.3.0.4" />
+			<dependency id="log4net" version="2.0.3" />
 		</dependencies>
 		<releaseNotes>
 		</releaseNotes>

--- a/Build/combres.log4net/combres.log4net.nuspec
+++ b/Build/combres.log4net/combres.log4net.nuspec
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<package> 
-  <metadata> 
-    <id>combres.log4net</id> 
-    <version>2.3.0.4</version> 
-	  <title>Combres.Log4Net</title> 
-    <authors>Buu Nguyen</authors> 
-    <owners>Buu Nguyen</owners>
-    <summary>Log4Net logging module for Combres.</summary> 
-	<description>Combres is a .NET library which minifies, compresses, combines, and caches JavaScript and CSS resources of ASP.NET and ASP.NET MVC web applications. This package contains the Log4Net adapter for Combres.</description> 
-    <projectUrl>https://github.com/buunguyen/combres</projectUrl>
-    <licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
-    <tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed logging log4net</tags>
-    <language>en-US</language> 
-	<dependencies>
-      <dependency id="combres" version="[2.3.0.4]" />
-      <dependency id="log4net" version="[2.0.3]" />
-    </dependencies> 
-	<releaseNotes>
-	</releaseNotes>
-  </metadata> 
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+	<metadata>
+		<id>combres.log4net</id>
+		<version>2.3.0.4</version>
+		<title>Combres.Log4Net</title>
+		<authors>Buu Nguyen</authors>
+		<owners>Buu Nguyen</owners>
+		<summary>Log4Net logging module for Combres.</summary>
+		<description>Combres is a .NET library which minifies, compresses, combines, and caches JavaScript and CSS resources of ASP.NET and ASP.NET MVC web applications. This package contains the Log4Net adapter for Combres.</description>
+		<projectUrl>https://github.com/buunguyen/combres</projectUrl>
+		<licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
+		<tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed logging log4net</tags>
+		<language>en-US</language>
+		<dependencies>
+			<dependency id="combres" version="[2.3.0.4]" />
+			<dependency id="log4net" version="[2.0.3]" />
+		</dependencies>
+		<releaseNotes>
+		</releaseNotes>
+	</metadata>
 </package>

--- a/Build/combres.mvc/combres.mvc.nuspec
+++ b/Build/combres.mvc/combres.mvc.nuspec
@@ -1,21 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<package> 
-  <metadata> 
-    <id>combres.mvc</id> 
-    <version>2.3.0.4</version> 
-	<title>Combres.Mvc</title> 
-    <authors>Buu Nguyen</authors> 
-    <owners>Buu Nguyen</owners>
-    <summary>MVC Extension for Combres.</summary> 
-	<description>Include extension methods for Combres to integrate more nicer with ASP.NET MVC applications.</description> 
-    <projectUrl>https://github.com/buunguyen/combres</projectUrl>
-    <licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
-    <tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed</tags>
-    <language>en-US</language> 
-	<dependencies>
-      <dependency id="combres" version="[2.3.0.4]" />
-    </dependencies> 
-    <releaseNotes>
-    </releaseNotes>
-  </metadata> 
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+	<metadata>
+		<id>combres.mvc</id>
+		<version>2.3.0.4</version>
+		<title>Combres.Mvc</title>
+		<authors>Buu Nguyen</authors>
+		<owners>Buu Nguyen</owners>
+		<summary>MVC Extension for Combres.</summary>
+		<description>Include extension methods for Combres to integrate more nicer with ASP.NET MVC applications.</description>
+		<projectUrl>https://github.com/buunguyen/combres</projectUrl>
+		<licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
+		<tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed</tags>
+		<language>en-US</language>
+		<dependencies>
+			<dependency id="combres" version="[2.3.0.4]" />
+		</dependencies>
+		<releaseNotes>
+		</releaseNotes>
+	</metadata>
 </package>

--- a/Build/combres.mvc/combres.mvc.nuspec
+++ b/Build/combres.mvc/combres.mvc.nuspec
@@ -13,7 +13,7 @@
 		<tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed</tags>
 		<language>en-US</language>
 		<dependencies>
-			<dependency id="combres" version="[2.3.0.4]" />
+			<dependency id="combres" version="2.3.0.4" />
 		</dependencies>
 		<releaseNotes>
 		</releaseNotes>

--- a/Build/combres/combres.nuspec
+++ b/Build/combres/combres.nuspec
@@ -15,17 +15,17 @@
 
 		<dependencies>
 			<group>
-				<dependency id="fasterflect" version="[2.1.3]" />
-				<dependency id="dotless" version="[1.4.1.0]" />
-				<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
-				<dependency id="AjaxMin" version="[5.14.5506.26202]" />
+				<dependency id="fasterflect" version="2.1.3" />
+				<dependency id="dotless" version="1.4.1.0" />
+				<dependency id="YUICompressor.NET" version="2.7.0.0" />
+				<dependency id="AjaxMin" version="5.14.5506.26202" />
 			</group>
 			<group targetFramework="net40">
-				<dependency id="fasterflect" version="[2.1.3]" />
-				<dependency id="dotless" version="[1.4.1.0]" />
-				<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
-				<dependency id="AjaxMin" version="[5.14.5506.26202]" />
-				<dependency id="WebActivatorEx" version="[2.0.6]" />
+				<dependency id="fasterflect" version="2.1.3" />
+				<dependency id="dotless" version="1.4.1.0" />
+				<dependency id="YUICompressor.NET" version="2.7.0.0" />
+				<dependency id="AjaxMin" version="5.14.5506.26202" />
+				<dependency id="WebActivatorEx" version="2.0.6" />
 			</group>
 		</dependencies>
 		<releaseNotes>

--- a/Build/combres/combres.nuspec
+++ b/Build/combres/combres.nuspec
@@ -1,34 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<package> 
-  <metadata> 
-    <id>combres</id> 
-    <version>2.3.0.4</version> 
-	<title>Combres</title> 
-    <authors>Buu Nguyen</authors> 
-    <owners>Buu Nguyen</owners>
-    <summary>Performance optimization library for ASP.NET and ASP.NET MVC applications.</summary> 
-	<description>.NET library which minifies, compresses, combines, and caches JavaScript and CSS resources of ASP.NET and ASP.NET MVC web applications. Simply put, this library helps your applications rank better with YSlow and PageSpeed.</description> 
-    <projectUrl>https://github.com/buunguyen/combres</projectUrl>
-    <licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
-    <tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed</tags>
-    <language>en-US</language> 
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+	<metadata>
+		<id>combres</id>
+		<version>2.3.0.4</version>
+		<title>Combres</title>
+		<authors>Buu Nguyen</authors>
+		<owners>Buu Nguyen</owners>
+		<summary>Performance optimization library for ASP.NET and ASP.NET MVC applications.</summary>
+		<description>.NET library which minifies, compresses, combines, and caches JavaScript and CSS resources of ASP.NET and ASP.NET MVC web applications. Simply put, this library helps your applications rank better with YSlow and PageSpeed.</description>
+		<projectUrl>https://github.com/buunguyen/combres</projectUrl>
+		<licenseUrl>https://github.com/buunguyen/combres/LICENSE</licenseUrl>
+		<tags>asp.net asp.net-mvc azure closure compression minification yui yuicompressor ajaxmin dotless yslow minification performance obfuscation optimization speed</tags>
+		<language>en-US</language>
 
-	<dependencies>
-		<group>
-			<dependency id="fasterflect" version="[2.1.3]" />
-			<dependency id="dotless" version="[1.4.1.0]" />
-			<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
-			<dependency id="AjaxMin" version="[5.14.5506.26202]" />
-		</group>
-		<group targetFramework="net40">
-			<dependency id="fasterflect" version="[2.1.3]" />
-			<dependency id="dotless" version="[1.4.1.0]" />
-			<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
-			<dependency id="AjaxMin" version="[5.14.5506.26202]" />
-			<dependency id="WebActivatorEx" version="[2.0.6]" />
-		</group>
-	</dependencies> 
-    <releaseNotes>
-    </releaseNotes>
-  </metadata> 
+		<dependencies>
+			<group>
+				<dependency id="fasterflect" version="[2.1.3]" />
+				<dependency id="dotless" version="[1.4.1.0]" />
+				<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
+				<dependency id="AjaxMin" version="[5.14.5506.26202]" />
+			</group>
+			<group targetFramework="net40">
+				<dependency id="fasterflect" version="[2.1.3]" />
+				<dependency id="dotless" version="[1.4.1.0]" />
+				<dependency id="YUICompressor.NET" version="[2.7.0.0]" />
+				<dependency id="AjaxMin" version="[5.14.5506.26202]" />
+				<dependency id="WebActivatorEx" version="[2.0.6]" />
+			</group>
+		</dependencies>
+		<releaseNotes>
+		</releaseNotes>
+	</metadata>
 </package>


### PR DESCRIPTION
Hi, I have updated NuGet dependencies versions. They were strict, and I could not install the combres together with other libraries in my website. So I have changes how dependencies are versioned. From "[x.x.x.x]" to "x.x.x.x".
Can you please check if everything is correct, and if it is so - release updated nuGet package?