### PR TITLE
fix Invalid Uri format

### DIFF
--- a/Combres/Common/Extensions/UrlExtensions.cs
+++ b/Combres/Common/Extensions/UrlExtensions.cs
@@ -68,6 +68,7 @@ namespace Combres
             if (headers["HTTP_HOST"] != null)
             {
                 var scheme = headers["HTTP_X_FORWARDED_PROTO"] ?? request.Url.Scheme;
+                scheme = scheme.Replace("\"", string.Empty);
                 return new Uri(scheme + Uri.SchemeDelimiter + headers["HTTP_HOST"]);
             }
             return request.Url;


### PR DESCRIPTION
headers["HTTP_X_FORWARDED_PROTO"] may have double quotes,

replace with string.Empty to avoid Invalid Uri Format Exception.